### PR TITLE
Update for TF2 version 8216530 (2023-07-25)

### DIFF
--- a/gamedata/tf2.rue.txt
+++ b/gamedata/tf2.rue.txt
@@ -10,7 +10,7 @@
                 "library"   "server"
                 "linux"     "@_ZN9CTFPlayer16GiveDefaultItemsEv"
                 // sub_104D4220:
-                "windows"   "\x56\x57\x8B\xF9\xFF\xB7\x40\x22\x00\x00\xE8\x2A\x2A\x2A\x2A\x83\xC4\x04"
+                "windows"   "\x56\x57\x8B\xF9\xFF\xB7\x2A\x22\x00\x00\xE8\x2A\x2A\x2A\x2A\x83\xC4\x04"
             }
             // "Item Whitelist file '%s' could not be found. All items" etc
             "CEconItemSystem::ReloadWhitelist"


### PR DESCRIPTION
This masks out the LSB of the member offset in `CTFPlayer::GiveDefaultItems` so it should be stable for a bit.